### PR TITLE
kdqTree: Added compatibility with pandas dataframes

### DIFF
--- a/examples/batch/kdqtree_batch_example.py
+++ b/examples/batch/kdqtree_batch_example.py
@@ -29,14 +29,11 @@ np.random.seed(123)
 
 # Import data
 # assumes the script is being run from the root directory.
-df_orig = pd.read_csv(
+df = pd.read_csv(
     os.path.join("src", "menelaus", "tools", "artifacts", "example_data.csv"),
     index_col="id",
     dtype={"drift": bool},
 )
-
-# Convert the categorical columns to dummy variables
-df = pd.concat([df_orig, pd.get_dummies(df_orig.cat, prefix="cat")], axis=1)
 
 # Capture the column which tells us when drift truly occurred
 drift_years = df.groupby("year")["drift"].apply(lambda x: x.unique()[0]).reset_index()
@@ -46,7 +43,6 @@ drift_years = df.groupby("year")["drift"].apply(lambda x: x.unique()[0]).reset_i
 # drift in 2010, 2013, and 2016. So:
 drift_years.loc[drift_years["year"].isin([2010, 2013, 2016]), "drift"] = True
 
-
 df.drop(columns=["cat", "confidence", "drift"], inplace=True)
 
 
@@ -55,11 +51,11 @@ status = pd.DataFrame(columns=["year", "drift"])
 det = KdqTree(input_type="batch")
 
 # Set up reference batch, using 2007 as reference year
-det.set_reference(df[df.year == 2007].values)
+det.set_reference(df[df.year == 2007].drop(columns=['year']))
 
 # Batch the data by year and run kdqTree
 for group, sub_df in df[df.year != 2007].groupby("year"):
-    det.update(sub_df.drop(columns=["year"]).values)
+    det.update(sub_df.drop(columns=["year"]))
     status = pd.concat(
         [status, pd.DataFrame({"year": [group], "drift": [det.drift_state]})],
         axis=0,
@@ -70,7 +66,7 @@ for group, sub_df in df[df.year != 2007].groupby("year"):
         plot_data[group] = det.to_plotly_dataframe()
         
         # option to specify reference batch to be any year 
-        #det.set_reference(df[df.year == XXXX].values)
+        # det.set_reference(df[df.year == XXXX].values)
 
 # Print out the true drift status, and that according to the detector.
 # The detector successfully identifies drift in every year but 2018;
@@ -110,5 +106,3 @@ for year, df_plot in plot_data.items():
 # Drift 3: change the correlation of item e and f in 2015 (go from correlation of 0 to correlation of 0.5)
 # Drift 4: change mean and var of H and persist it from 2018 on
 # Drift 5: change mean and var just for a year of J in 2021
-
-

--- a/examples/batch/partitioner_plots_example.py
+++ b/examples/batch/partitioner_plots_example.py
@@ -52,7 +52,7 @@ fig = px.treemap(
 )
 fig.update_traces(root_color="lightgrey")
 # fig.show()
-fig.write_html(f"example_partitioner_lots_basic_plot.html")
+fig.write_html(f"example_partitioner_plots_basic_plot.html")
 
 ############## Filter by depth ##############
 kp = KDQTreePartitioner(count_ubound=25)
@@ -72,7 +72,7 @@ fig = px.treemap(
 )
 fig.update_traces(root_color="lightgrey")
 # fig.show()
-fig.write_html(f"example_partitioner_lots_basic_plot_depth.html")
+fig.write_html(f"example_partitioner_plots_basic_plot_depth.html")
 
 
 ################################################################################
@@ -99,7 +99,7 @@ fig = px.treemap(
 )
 fig.update_traces(root_color="lightgrey")
 # fig.show()
-fig.write_html(f"example_partitioner_lots_modifications1_count.html")
+fig.write_html(f"example_partitioner_plots_modifications1_count.html")
 
 
 ############## Display additional information ##############
@@ -114,7 +114,7 @@ fig.update_traces(
     root_color="lightgrey", textinfo="label+current path"
 )  # see textinfo in https://plotly.com/python/reference/treemap/
 # fig.show()
-fig.write_html(f"example_partitioner_lots_modifications2_path.html")
+fig.write_html(f"example_partitioner_plots_modifications2_path.html")
 
 
 ##### Access the plot and color using the Kulldorff Spatial Scan Statistic (KSS) #####
@@ -130,7 +130,7 @@ fig = px.treemap(
 )
 fig.update_traces(root_color="lightgrey")
 # fig.show()
-fig.write_html(f"example_partitioner_lots_modifications3_kss.html")
+fig.write_html(f"example_partitioner_plots_modifications3_kss.html")
 
 
 ############# Outline the cells according to the direction of change in counts #############
@@ -155,7 +155,7 @@ fig.update_traces(
     root_color="lightgrey",
 )
 # fig.show()
-fig.write_html(f"example_partitioner_lots_modifications4_outline.html")
+fig.write_html(f"example_partitioner_plots_modifications4_outline.html")
 
 
 ################################################################################
@@ -190,7 +190,7 @@ fig.update_traces(
     root_color="lightgrey",
 )
 # fig.show()
-fig.write_html(f"example_partitioner_lots_alternatives_sunburst.html")
+fig.write_html(f"example_partitioner_plots_alternatives_sunburst.html")
 
 
 ############# Icicle Plot #############
@@ -207,4 +207,4 @@ fig.update_traces(
     root_color="lightgrey",
 )
 # fig.show()
-fig.write_html(f"example_partitioner_lots_alternatives_icicle.html")
+fig.write_html(f"example_partitioner_plots_alternatives_icicle.html")

--- a/examples/streaming/data_drift_example.py
+++ b/examples/streaming/data_drift_example.py
@@ -139,7 +139,7 @@ data = df[["var1", "var2"]]
 
 plot_data = {}
 for i in range(len(df)):
-    det.update(data.iloc[[i]].values)
+    det.update(data.iloc[[i]])
     status.loc[i] = [i, data.iloc[i, 0], data.iloc[i, 1], det.drift_state]
     if det.drift_state is not None:
         # capture the visualization data

--- a/tests/menelaus_tests/test_kdqtree_partitioner.py
+++ b/tests/menelaus_tests/test_kdqtree_partitioner.py
@@ -178,6 +178,14 @@ def test_to_plotly_dataframe():
     assert set(df_plot.columns) == set(
         ["name", "idx", "parent_idx", "cell_count", "depth", "count_diff", "kss"]
     )
+    assert df_plot.loc[1:, "name"].apply(lambda x: True if ("ax" in x) else False).all()
+    df_plot = kp.to_plotly_dataframe(tree_id2="fill1", max_depth=1, input_cols=["col1", "col2", "col3"])
+    assert df_plot.shape[0] == 3
+    assert set(df_plot.columns) == set(
+        ["name", "idx", "parent_idx", "cell_count", "depth", "count_diff", "kss"]
+    )
+    assert df_plot.loc[1:, "name"].apply(lambda x: True if ("col" in x) else False).all()
+    assert df_plot.loc[1:, "name"].apply(lambda x: True if ("ax" not in x) else False).all()
 
 
 def test_as_text():


### PR DESCRIPTION
## Changes
- Methods `set_reference` and `update` in `kdq_tree.py` can now accept data in the form of either numpy array (previous implementation) or pandas dataframe (added capability)
- In the `set_reference` method:
    - We check if the data is a pandas dataframe. If so, we call `_inner_set_reference` with `data.values` and set `self.input_cols` to be the `data.columns`.
    - If the data is instead a numpy array, we call `_inner_set_reference` with `data`
    - If the data is neither a df nor an nparray, we raise a ValueError saying that it can only be one of these two formats.
- In the `update` method:
    - We check if the data is a pandas dataframe. If so, and `self.input_cols` is not `None`, we check to make sure that the columns of the new data match `self.input_cols`. Then we assign `ary` to be `data.values`.
    - If the data is instead a numpy array, we just set `ary` to be `data` itself.
    - If the data is neither a df nor an nparray, we raise a ValueError saying that it can only be one of these two formats.
- Added a convenience argument `input_cols` to the `to_plotly_dataframe` method in `kdq_tree.py`. This is passed to the `to_plotly_dataframe` method in `KDQTreePartitioner.py`. It is then passed to the `as_flattened_array` method in `KDQTreePartitioner.py`. Here, it is used in the definition of `axis_name` when generating the html files.

### HTML File Output Difference
- Basic Plot from `partitioner_plots_example.py` with original implementation:
<img width="834" alt="basic_plot_original" src="https://user-images.githubusercontent.com/33501059/174150440-de48b0ff-ae12-4cc3-98d5-2521b08906fb.PNG">

- Basic Plot from `partitioner_plots_example.py` after adding `input_cols=["col1", "col2", "col3"]` to the call to `to_plotly_dataframe`:
<img width="835" alt="basic_plot_new" src="https://user-images.githubusercontent.com/33501059/174150456-178426c4-1e3c-4319-aef0-c64fa906b243.PNG">