### PR TITLE
Add unit tests for kdqTree

### DIFF
--- a/src/menelaus/data_drift/kdq_tree.py
+++ b/src/menelaus/data_drift/kdq_tree.py
@@ -212,7 +212,7 @@ class KdqTree(DriftDetector):
             elif self.input_cols is not None:
                 if not data.columns.equals(self.input_cols):
                     raise ValueError(
-                        "Columns of new batch of data must match with columns of reference data."
+                        "Columns of new data must match with columns of reference data."
                     )
             ary = data.values
         elif isinstance(data, np.ndarray):

--- a/src/menelaus/data_drift/kdq_tree.py
+++ b/src/menelaus/data_drift/kdq_tree.py
@@ -210,13 +210,15 @@ class KdqTree(DriftDetector):
                 # input. This will also fire if set_reference has been used with
                 # a dataframe.
                 self.input_cols = data.columns
-            else:
+            elif self.input_cols is not None:
                 if not data.columns.equals(self.input_cols):
                     raise ValueError(
                         "Columns of new data must match with columns of reference data."
                     )
             ary = data.values
         elif isinstance(data, np.ndarray):
+            # This allows starting with a dataframe, then later passing bare
+            # numpy arrays. For now, assume users are not miscreants.
             ary = data
         else:
             raise ValueError(

--- a/src/menelaus/data_drift/kdq_tree.py
+++ b/src/menelaus/data_drift/kdq_tree.py
@@ -228,7 +228,7 @@ class KdqTree(DriftDetector):
             if self.input_type == "batch":
                 # this will both reset the detector and initialize the reference
                 # kdq-tree.
-                self.set_reference(data)
+                self.set_reference(self.ref_data)
             else:
                 self.reset()
 
@@ -263,6 +263,8 @@ class KdqTree(DriftDetector):
 
                     else:
                         self.drift_state = "drift"
+                        if isinstance(data, pd.DataFrame):
+                            self.input_cols = data.columns
                         self.ref_data = ary
 
     def _get_critical_kld(self, ref_counts):

--- a/tests/menelaus/test_kdq_tree.py
+++ b/tests/menelaus/test_kdq_tree.py
@@ -1,6 +1,5 @@
 """Module to check correctness of kdqTree"""
 import copy
-from matplotlib.pyplot import new_figure_manager
 import pytest
 import numpy as np
 import pandas as pd

--- a/tests/menelaus/test_kdq_tree.py
+++ b/tests/menelaus/test_kdq_tree.py
@@ -1,5 +1,6 @@
 """Module to check correctness of kdqTree"""
 import copy
+from matplotlib.pyplot import new_figure_manager
 import pytest
 import numpy as np
 import pandas as pd
@@ -62,9 +63,15 @@ def test_reset_stream(kdq_det_stream):
     det = copy.copy(kdq_det_stream)
 
     # given that the detector just drifted, next step ought not to regardless of input
-    new_sample = pd.DataFrame(np.random.sample((1, NUM_FEATURES))).values
+    new_input_col_names = list(range(5, 5 + NUM_FEATURES))
+    new_sample = pd.DataFrame(
+        np.random.sample((1, NUM_FEATURES)), columns=new_input_col_names
+    )
     det.update(new_sample)
     assert det.drift_state is None
+    det.reset()
+    det.update(new_sample)
+    assert det.input_cols.equals(new_sample.columns)
 
 
 def test_reset_batch(kdq_det_batch):
@@ -74,14 +81,59 @@ def test_reset_batch(kdq_det_batch):
     assert det.drift_state is None
 
 
-def test_validation(kdq_det_stream):
+def test_set_reference(kdq_det_batch):
+    det = copy.copy(kdq_det_batch)
+    new_sample = pd.DataFrame(np.random.sample((1, NUM_FEATURES))).values
+    det.set_reference(new_sample)
+    det.update(new_sample)
+    assert det.drift_state is None
+
+    # make sure that input_cols is set appropriately when initialized
+    det = det = KdqTree(input_type="batch", count_ubound=1, bootstrap_samples=10)
+    new_sample = pd.DataFrame(np.random.sample((1, NUM_FEATURES)))
+    det.set_reference(new_sample)
+    assert det.input_cols.equals(new_sample.columns)
+
+
+def test_init_validation_stream(kdq_det_stream):
     with pytest.raises(ValueError) as _:
         det = KdqTree(window_size=None, input_type="stream")
     with pytest.raises(ValueError) as _:
         det = KdqTree(window_size=-5, input_type="stream")
+
+
+def test_set_reference_validation_stream(kdq_det_stream):
     with pytest.raises(ValueError) as _:
         det = copy.copy(kdq_det_stream)
-        det.set_reference(pd.DataFrame(np.random.sample((1, NUM_FEATURES))).values)
+        det.set_reference("garbage input")
+
+
+def test_set_reference_validation_batch(kdq_det_batch):
+    det = copy.copy(kdq_det_batch)
+    with pytest.raises(ValueError) as _:
+        det.set_reference("garbage input")
+
+
+def test_update_validation_batch(kdq_det_batch):
+    det = copy.copy(kdq_det_batch)
+    with pytest.raises(ValueError) as _:
+        det.update("garbage input")
+
+    # this should not raise a ValueError in the current implementation
+    # since the kdq_det_batch fixture is initialized with a numpy array
+    new_name_df = pd.DataFrame(
+        np.random.sample((10, NUM_FEATURES)), columns=list(range(5, 5 + NUM_FEATURES))
+    )
+    det.update(new_name_df)
+
+    # this *should* raise a ValueError in the current implementation
+    with pytest.raises(ValueError) as _:
+        det.set_reference(new_name_df)
+        bad_name_df = pd.DataFrame(
+            np.random.sample((10, NUM_FEATURES)),
+            columns=list(range(10, 10 + NUM_FEATURES)),
+        )
+        det.update(bad_name_df)
 
 
 def test_viz_dataframe(kdq_det_batch):
@@ -92,11 +144,8 @@ def test_viz_dataframe(kdq_det_batch):
     assert set(plot_df.columns) == set(
         ["name", "idx", "parent_idx", "cell_count", "depth", "count_diff", "kss"]
     )
-
-
-def test_set_reference_batch(kdq_det_batch):
-    det = copy.copy(kdq_det_batch)
-    new_sample = pd.DataFrame(np.random.sample((1, NUM_FEATURES))).values
-    det.set_reference(new_sample)
-    det.update(new_sample)
-    assert det.drift_state is None
+    new_input_col_names = list(range(5, 5 + NUM_FEATURES))
+    plot_df = kdq_det_batch.to_plotly_dataframe(input_cols=new_input_col_names)
+    assert set(new_input_col_names) == set(
+        set(plot_df["name"].str.split(" ").str[0][1:].astype("int").unique())
+    )

--- a/tests/menelaus/test_kdqtree_partitioner.py
+++ b/tests/menelaus/test_kdqtree_partitioner.py
@@ -179,13 +179,21 @@ def test_to_plotly_dataframe():
         ["name", "idx", "parent_idx", "cell_count", "depth", "count_diff", "kss"]
     )
     assert df_plot.loc[1:, "name"].apply(lambda x: True if ("ax" in x) else False).all()
-    df_plot = kp.to_plotly_dataframe(tree_id2="fill1", max_depth=1, input_cols=["col1", "col2", "col3"])
+    df_plot = kp.to_plotly_dataframe(
+        tree_id2="fill1", max_depth=1, input_cols=["col1", "col2", "col3"]
+    )
     assert df_plot.shape[0] == 3
     assert set(df_plot.columns) == set(
         ["name", "idx", "parent_idx", "cell_count", "depth", "count_diff", "kss"]
     )
-    assert df_plot.loc[1:, "name"].apply(lambda x: True if ("col" in x) else False).all()
-    assert df_plot.loc[1:, "name"].apply(lambda x: True if ("ax" not in x) else False).all()
+    assert (
+        df_plot.loc[1:, "name"].apply(lambda x: True if ("col" in x) else False).all()
+    )
+    assert (
+        df_plot.loc[1:, "name"]
+        .apply(lambda x: True if ("ax" not in x) else False)
+        .all()
+    )
 
 
 def test_as_text():
@@ -221,3 +229,7 @@ def test_missing_tree_flattened_array():
         root, tree_id1="build", tree_id2="garbage", output=out
     )
     assert all([guy["count_diff"] <= 0 for guy in out])
+
+
+def test_empty_node_fill():
+    assert KDQTreeNode.fill(np.array([]), None, 10, "foo") is None


### PR DESCRIPTION
Fixes #45 .

This should get the repo to 100% coverage, instead of the former 99%. The 99% was due to a single line not executing, so it was neglected, but this masked drops in coverage due to rounding as we made further changes. Hitting 100% should stop this from happening in the future, so unit test updates happen as we go for sure.

This PR adds unit tests for that.