### PR TITLE
Fix kdq-tree batch example in documentation example notebook

### DIFF
--- a/docs/source/examples/data_drift/data_drift_examples.ipynb
+++ b/docs/source/examples/data_drift/data_drift_examples.ipynb
@@ -663,8 +663,7 @@
     "# the seed is important to reproduce exact behavior.\n",
     "np.random.seed(123)\n",
     "\n",
-    "# Convert the categorical columns to dummy variables\n",
-    "df = pd.concat([example_data, pd.get_dummies(example_data.cat, prefix=\"cat\")], axis=1)\n",
+    "df = example_data\n",
     "\n",
     "# Capture the column which tells us when drift truly occurred\n",
     "drift_years = df.groupby(\"year\")[\"drift\"].apply(lambda x: x.unique()[0]).reset_index()\n",
@@ -683,7 +682,7 @@
     "det = KdqTree(input_type=\"batch\")\n",
     "\n",
     "# Set up reference batch, using 2007 as reference year\n",
-    "det.set_reference(df[df.year == 2007].values)"
+    "det.set_reference(df[df.year == 2007].drop(columns=['year']))"
    ]
   },
   {
@@ -694,7 +693,7 @@
    "source": [
     "# Batch the data by year and run kdqTree\n",
     "for group, sub_df in df[df.year != 2007].groupby(\"year\"):\n",
-    "    det.update(sub_df.drop(columns=[\"year\"]).values)\n",
+    "    det.update(sub_df.drop(columns=[\"year\"]))\n",
     "    status = pd.concat(\n",
     "        [status, pd.DataFrame({\"year\": [group], \"drift\": [det.drift_state]})],\n",
     "        axis=0,\n",
@@ -705,7 +704,7 @@
     "        plot_data[group] = det.to_plotly_dataframe()\n",
     "        \n",
     "        # option to specify reference batch to be any year \n",
-    "        #det.set_reference(df[df.year == XXXX].values)"
+    "        #det.set_reference(df[df.year == XXXX])"
    ]
   },
   {
@@ -786,7 +785,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('.venv': venv)",
+   "display_name": "Python 3.10.2 ('molten_env')",
    "language": "python",
    "name": "python3"
   },
@@ -800,12 +799,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.2"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "3421042059aa98a04347b62f46a0ecb50f80a487080b28abc1f29aad428e3e88"
+    "hash": "cebda30e5482c3c83cb9c7c7d8ef1c1d1f67dcf93284b9e88f69b68f560a7bf6"
    }
   }
  },


### PR DESCRIPTION
The current version seems to have a) not dropped the "year" column from the input data and b) retained and uncommented some lines from an earlier version of the example to do with using dummy variables for categoricals. The former shouldn't be included as a feature, and the latter isn't handled well, so the example doesn't function.

This fixes it.