### PR TITLE
Minor updates to constrain Python version used in installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _build
 *.DS_Store
 .idea/
 *.png
+*.tox*

--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,7 @@ Create a virtual environment as desired, e.g. ``python -m venv ./venv``, then:
    cd ./menelaus/
    pip install -e .[dev] 
 
-Menelaus will generally work with Python 3.7 or higher; more specific version
-testing is in the works.
+Menelaus should work with Python 3.8 or higher.
 
 Getting Started
 ============================

--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,16 @@ Create a virtual environment as desired, e.g. ``python -m venv ./venv``, then:
    #First, clone the git repo, then:
    cd ./menelaus/
    pip install -e .[dev] 
+   
 
-Menelaus should work with Python 3.8 or higher.
+Menelaus should work with Python 3.8 or higher. You may use the ``pyenv`` library to accomplish this.
+
+.. code-block:: python
+
+   pyenv install 3.7.4
+   pyenv virtualenv 3.7.4 menelaus
+   pyenv local menelaus
+   
 
 Getting Started
 ============================

--- a/README.rst
+++ b/README.rst
@@ -131,13 +131,7 @@ Create a virtual environment as desired, e.g. ``python -m venv ./venv``, then:
    pip install -e .[dev] 
    
 
-Menelaus should work with Python 3.8 or higher. You may use the ``pyenv`` library to accomplish this.
-
-.. code-block:: python
-
-   pyenv install 3.7.4
-   pyenv virtualenv 3.7.4 menelaus
-   pyenv local menelaus
+Menelaus should work with Python 3.8 or higher. 
    
 
 Getting Started

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
 include_package_data = True
 install_requires =
    pandas
-   numpy >= 1.22.0
+   numpy >= 1.22.0 # This is due to the call to np.quantile in data_drift.kdq_tree, which uses an updated arg name. The code is otherwise compatible with python >= 3.5.
    sklearn
    scipy
    joblib

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py{27,35,36,37,38,39,310}
+envlist = py{27, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39}
 skip_missing_interpreters = true
 
 [testenv]
-deps = pytest, pytest-cov
+deps = 
+	pytest
+	pytest-cov
 commands = 
 	pytest tests/menelaus --cov=src/ --cov-report term
 	coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py{27,35,36,37,38,39,310}
+skip_missing_interpreters = true
+
+[testenv]
+deps = pytest, pytest-cov
+commands = 
+	pytest tests/menelaus --cov=src/ --cov-report term
+	coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39}
+envlist = py{38, 39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Closes #2 

Updates `README.md`, `tox.ini`, and `setup.cfg` to reference `Python 3.8` as minimum version needed for installation.