### PR TITLE
Reshape input as part of validation.

### DIFF
--- a/src/menelaus/change_detection/adwin.py
+++ b/src/menelaus/change_detection/adwin.py
@@ -106,7 +106,12 @@ class ADWIN(StreamingDetector):
             # note that the other attributes should *not* be initialized after drift
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
+
+        # the array should have a single element after validation.
+        X = X[0][0]
+
         # add new sample to the head of the window
         self._window_size += 1
         self._add_sample(X)

--- a/src/menelaus/change_detection/cusum.py
+++ b/src/menelaus/change_detection/cusum.py
@@ -82,6 +82,7 @@ class CUSUM(StreamingDetector):
             self.sd_hat = np.std(self._stream[-self.burn_in :])
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
         self._stream.append(X)
 

--- a/src/menelaus/change_detection/page_hinkley.py
+++ b/src/menelaus/change_detection/page_hinkley.py
@@ -82,6 +82,8 @@ class PageHinkley(StreamingDetector):
         """
         if self.drift_state == "drift":
             self.reset()
+        
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
 
         self._mean = self._mean + (X - self._mean) / self.samples_since_reset

--- a/src/menelaus/concept_drift/adwin_outcome.py
+++ b/src/menelaus/concept_drift/adwin_outcome.py
@@ -86,4 +86,7 @@ class ADWINOutcome(ADWIN):
 
         # This class is here to avoid asking the user to provide such a direct
         # function of (y_true, y_pred) in the X argument, which is unintuitive.
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
+        # the arrays should have a single element after validation.
+        y_true, y_pred = y_true[0], y_pred[0]
         super().update(new_value, y_true=None, y_pred=None)

--- a/src/menelaus/concept_drift/ddm.py
+++ b/src/menelaus/concept_drift/ddm.py
@@ -74,7 +74,10 @@ class DDM(StreamingDetector):
         if self.drift_state == "drift":
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
+        # the arrays should have a single element after validation.
+        y_true, y_pred = y_true[0], y_pred[0]
         classifier_result = int(y_pred != y_true)
 
         # with each sample, update estimate of error and its std, along with minimums

--- a/src/menelaus/concept_drift/eddm.py
+++ b/src/menelaus/concept_drift/eddm.py
@@ -81,7 +81,10 @@ class EDDM(StreamingDetector):
         if self.drift_state == "drift":
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
+        # the arrays should have a single element after validation.
+        y_true, y_pred = y_true[0], y_pred[0]        
         classifier_result = int(y_pred == y_true)
 
         # found a new error, so update

--- a/src/menelaus/concept_drift/lfr.py
+++ b/src/menelaus/concept_drift/lfr.py
@@ -146,7 +146,11 @@ class LinearFourRates(StreamingDetector):
         if self.drift_state == "drift":
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
+        # the arrays should have a single element after validation.
+        y_true, y_pred = y_true[0], y_pred[0]
+
         y_p = 1 * y_pred
         y_t = 1 * y_true
 

--- a/src/menelaus/concept_drift/stepd.py
+++ b/src/menelaus/concept_drift/stepd.py
@@ -78,7 +78,10 @@ class STEPD(StreamingDetector):
         if self.drift_state == "drift":
             self.reset()
 
+        X, y_true, y_pred = super()._validate_input(X, y_true, y_pred)
         super().update(X, y_true, y_pred)
+        # the arrays should have a single element after validation.
+        y_true, y_pred = y_true[0], y_pred[0]        
         classifier_result = int(y_pred == y_true)
         self._s += classifier_result
 


### PR DESCRIPTION
Fix #103 .

Previously, `validate_input` only did some sanity checking, but didn't reshape anything.
Now, `validate_input` will try to coerce input so that it matches expectations for streaming/batch detectors.

Notes:
- for the univariate streaming detectors, picking the first element out of the array before doing comparison is slightly faster (and hopefully easier to understand downstream)
- MD3 still needs switching to a new ABC, which will call for adding validation there.

TODO:
- [ ] move validate calls to child classes (update, set_reference - take care to copy the dataframes for the latter)
- [ ] update docstrings to be explicit about one-sample vs. more-than-one-sample for streaming vs batch
- [ ] unit tests (batch should not be 1 x n, streaming should be 1 x n)