### PR TITLE
Rename ADWIN concept drift detector

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: tests | coverage
+name: tests | coverage 100%
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Menelaus implements the following drift detectors.
 |------------------|---------------------------------------------------------------|--------------|-----------|-------|
 | Change detection | Cumulative Sum Test                                           | CUSUM        | x         |       |
 | Change detection | Page-Hinkley                                                  | PH           | x         |       |
-| Concept drift    | ADaptive WINdowing                                            | ADWIN        | x         |       |
+| Change detection    | ADaptive WINdowing                                            | ADWIN        | x         |       |
 | Concept drift    | Drift Detection Method                                        | DDM          | x         |       |
 | Concept drift    | Early Drift Detection Method                                  | EDDM         | x         |       |
 | Concept drift    | Linear Four Rates                                             | LFR          | x         |       |
@@ -68,7 +68,8 @@ documentation on [ReadTheDocs](https://menelaus.readthedocs.io/en/latest/).
     pre-defined range.
 -   Concept drift detectors monitor the performance characteristics of a
     given model, trying to identify shifts in the joint distribution of
-    the data\'s feature values and their labels.
+    the data\'s feature values and their labels. Note that change detectors 
+    can also be applied in this context.
 -   Data drift detectors monitor the distribution of the features; in
     that sense, they are model-agnostic. Such changes in distribution
     might be to single variables or to the joint distribution of all the
@@ -114,7 +115,7 @@ Generally, the workflow for using a detector, given some data, is as
 follows:
 
 ```python
-from menelaus.concept_drift import ADWINOutcome
+from menelaus.concept_drift import ADWINAccuracy
 from menelaus.data_drift import KdqTreeStreaming
 from menelaus.datasets import fetch_rainfall_data
 from menelaus.ensemble import StreamingEnsemble, eval_simple_majority
@@ -125,7 +126,7 @@ df = fetch_rainfall_data()
 
 
 # use a concept drift detector (response-only)
-detector = ADWINOutcome()
+detector = ADWINAccuracy()
 for i, row in df.iterrows():
     detector.update(X=None, y_true=row['rain'], y_pred=0)
     assert detector.drift_state != "drift", f"Drift detected in row {i}"
@@ -141,7 +142,7 @@ for i, row in df.iterrows():
 # use ensemble detector (detectors + voting function)
 ensemble = StreamingEnsemble(
   {
-    'a': ADWINOutcome(),
+    'a': ADWINAccuracy(),
     'k': KdqTreeStreaming(window_size=5)
   },
   eval_simple_majority

--- a/docs/source/examples/concept_drift/concept_drift_examples.ipynb
+++ b/docs/source/examples/concept_drift/concept_drift_examples.ipynb
@@ -52,7 +52,7 @@
                 "from sklearn.linear_model import SGDClassifier\n",
                 "from sklearn import svm\n",
                 "from sklearn.base import clone\n",
-                "from menelaus.concept_drift import LinearFourRates, ADWINOutcome, DDM, EDDM, STEPD, MD3\n",
+                "from menelaus.concept_drift import LinearFourRates, ADWINAccuracy, DDM, EDDM, STEPD, MD3\n",
                 "from menelaus.datasets import fetch_circle_data, fetch_rainfall_data"
             ]
         },
@@ -261,7 +261,7 @@
             "source": [
                 "ADWIN is a change detection algorithm that can be used to monitor a real-valued number. ADWIN maintains a window of the data stream, which grows to the right as new elements are received. When the mean of the feature in one of the subwindows is different enough, ADWIN drops older elements in its window until this ceases to be the case.\n",
                 "\n",
-                "It can be used to monitor the accuracy of a classifier by checking `y_true == y_pred` at each time step. So, for convenience, `concept_drift.ADWINOutcome`, takes `y_true` and `y_pred` as arugments, as shown below. `change_detection.ADWIN` can be used more generally, as shown in the change detection examples."
+                "It can be used to monitor the accuracy of a classifier by checking `y_true == y_pred` at each time step. So, for convenience, `concept_drift.ADWINAccuracy`, takes `y_true` and `y_pred` as arugments, as shown below. `change_detection.ADWIN` can be used more generally, as shown in the change detection examples."
             ]
         },
         {
@@ -286,7 +286,7 @@
                 "acc_orig = np.cumsum(clf.predict(X_test) == y_true)\n",
                 "acc_orig = acc_orig / np.arange(1, 1 + len(acc_orig))\n",
                 "\n",
-                "adwin = ADWINOutcome()\n",
+                "adwin = ADWINAccuracy()\n",
                 "\n",
                 "# Set up DF to record results.\n",
                 "status = pd.DataFrame(\n",
@@ -383,7 +383,7 @@
                 "\n",
                 "plt.legend(loc='lower right')\n",
                 "plt.show()\n",
-                "# plt.savefig(\"example_ADWINOutcome.png\")"
+                "# plt.savefig(\"example_ADWINAccuracy.png\")"
             ]
         },
         {

--- a/examples/concept_drift_examples.py
+++ b/examples/concept_drift_examples.py
@@ -40,7 +40,7 @@ from sklearn.naive_bayes import GaussianNB
 from sklearn.linear_model import SGDClassifier
 from sklearn import svm
 from sklearn.base import clone
-from menelaus.concept_drift import LinearFourRates, ADWINOutcome, DDM, EDDM, STEPD, MD3
+from menelaus.concept_drift import LinearFourRates, ADWINAccuracy, DDM, EDDM, STEPD, MD3
 from menelaus.datasets import fetch_circle_data, fetch_rainfall_data
 
 
@@ -214,7 +214,7 @@ plt.show()
 
 # ADWIN is a change detection algorithm that can be used to monitor a real-valued number. ADWIN maintains a window of the data stream, which grows to the right as new elements are received. When the mean of the feature in one of the subwindows is different enough, ADWIN drops older elements in its window until this ceases to be the case.
 # 
-# It can be used to monitor the accuracy of a classifier by checking `y_true == y_pred` at each time step. So, for convenience, `concept_drift.ADWINOutcome`, takes `y_true` and `y_pred` as arugments, as shown below. `change_detection.ADWIN` can be used more generally, as shown in the change detection examples.
+# It can be used to monitor the accuracy of a classifier by checking `y_true == y_pred` at each time step. So, for convenience, `concept_drift.ADWINAccuracy`, takes `y_true` and `y_pred` as arugments, as shown below. `change_detection.ADWIN` can be used more generally, as shown in the change detection examples.
 
 # In[ ]:
 
@@ -235,7 +235,7 @@ clf.fit(X_train, y_train)
 acc_orig = np.cumsum(clf.predict(X_test) == y_true)
 acc_orig = acc_orig / np.arange(1, 1 + len(acc_orig))
 
-adwin = ADWINOutcome()
+adwin = ADWINAccuracy()
 
 # Set up DF to record results.
 status = pd.DataFrame(
@@ -326,7 +326,7 @@ plt.hlines(
 
 plt.legend(loc='lower right')
 plt.show()
-# plt.savefig("example_ADWINOutcome.png")
+# plt.savefig("example_ADWINAccuracy.png")
 
 
 # 

--- a/examples/data_drift_examples.py
+++ b/examples/data_drift_examples.py
@@ -43,12 +43,6 @@ example_data = make_example_batch_data()
 circle_data = fetch_circle_data()
 
 
-# In[ ]:
-
-
-circle_data.shape
-
-
 # ## Confidence Distribution Batch Detection (CDBD)
 
 # This section details how to setup, run, and produce plots for CDBD. This script

--- a/src/menelaus/change_detection/adwin.py
+++ b/src/menelaus/change_detection/adwin.py
@@ -13,7 +13,7 @@ from menelaus.drift_detector import StreamingDetector
 
 
 class ADWIN(StreamingDetector):
-    """ADWIN (ADaptive WINdowing) is a drift detection algorithm which uses a
+    """ADWIN (ADaptive WINdowing) is a change detection algorithm which uses a
     sliding window to estimate the running mean and variance of a given
     real-valued number.
 

--- a/src/menelaus/concept_drift/__init__.py
+++ b/src/menelaus/concept_drift/__init__.py
@@ -12,7 +12,7 @@ ability to focus on an isolated performance metric, such as accuracy, or
 multiple metrics simultaneously, such as true positive, false positive, true
 negative, and false negative rates. 
 """
-from menelaus.concept_drift.adwin_outcome import ADWINOutcome
+from menelaus.concept_drift.adwin_accuracy import ADWINAccuracy
 from menelaus.concept_drift.ddm import DDM
 from menelaus.concept_drift.eddm import EDDM
 from menelaus.concept_drift.lfr import LinearFourRates

--- a/src/menelaus/concept_drift/adwin_accuracy.py
+++ b/src/menelaus/concept_drift/adwin_accuracy.py
@@ -1,10 +1,10 @@
 from menelaus.change_detection.adwin import ADWIN
 
 
-class ADWINOutcome(ADWIN):
+class ADWINAccuracy(ADWIN):
     """ADWIN (ADaptive WINdowing) is a drift detection algorithm which uses a
     sliding window to estimate the running mean and variance of a given
-    real-valued number. ADWINOutcome specifically expects ``y_true``,
+    real-valued number. ADWINAccuracy specifically expects ``y_true``,
     ``y_pred``, and uses that input to monitor the running accuracy of a
     classifier. To use ADWIN to monitor other values, see
     ``change_detection.ADWIN``.

--- a/src/menelaus/concept_drift/adwin_accuracy.py
+++ b/src/menelaus/concept_drift/adwin_accuracy.py
@@ -2,12 +2,13 @@ from menelaus.change_detection.adwin import ADWIN
 
 
 class ADWINAccuracy(ADWIN):
-    """ADWIN (ADaptive WINdowing) is a drift detection algorithm which uses a
+    """ADWIN (ADaptive WINdowing) is a change detection algorithm which uses a
     sliding window to estimate the running mean and variance of a given
-    real-valued number. ADWINAccuracy specifically expects ``y_true``,
-    ``y_pred``, and uses that input to monitor the running accuracy of a
-    classifier. To use ADWIN to monitor other values, see
-    ``change_detection.ADWIN``.
+    real-valued number. It can be applied as a concept drift detector by
+    monitoring a performance metric for a given classifier. ADWINAccuracy
+    specifically expects ``y_true``, ``y_pred``, and uses that input to monitor
+    the running accuracy of a classifier. To use ADWIN to monitor other values,
+    see ``change_detection.ADWIN``.
 
     As each sample is added, ADWIN stores a running estimate (mean and variance)
     for a given statistic, calculated over a sliding window which will grow to

--- a/tests/menelaus/concept_drift/test_adwin_accuracy.py
+++ b/tests/menelaus/concept_drift/test_adwin_accuracy.py
@@ -1,9 +1,9 @@
 import pytest
-from menelaus.concept_drift.adwin_outcome import ADWINOutcome
+from menelaus.concept_drift.adwin_accuracy import ADWINAccuracy
 
 
 def test_aliased_input():
-    det = ADWINOutcome()
+    det = ADWINAccuracy()
 
     det.update(y_true=1, y_pred=0)
     assert det.total_samples == 1


### PR DESCRIPTION
- ADWINOutcome is renamed ADWINAccuracy, since that's the specific metric it's monitoring. Too long, stylewise, but less ambiguous with the API.
- Update the coverage badge name to be clear what the passing criterion is.