### PR TITLE
Add LTF-inspired drift injection functions

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,3 +1,19 @@
+@inproceedings{LTFmethods,
+  title = 	 {{LTF}: A Label Transformation Framework for Correcting Label Shift},
+  author =       {Guo, Jiaxian and Gong, Mingming and Liu, Tongliang and Zhang, Kun and Tao, Dacheng},
+  booktitle = 	 {Proceedings of the 37th International Conference on Machine Learning},
+  pages = 	 {3843--3853},
+  year = 	 {2020},
+  editor = 	 {III, Hal Daumé and Singh, Aarti},
+  volume = 	 {119},
+  series = 	 {Proceedings of Machine Learning Research},
+  month = 	 {13--18 Jul},
+  publisher =    {PMLR},
+  pdf = 	 {http://proceedings.mlr.press/v119/guo20d/guo20d.pdf},
+  url = 	 {https://proceedings.mlr.press/v119/guo20d.html},
+  abstract = 	 {Distribution shift is a major obstacle to the deployment of current deep learning models on real-world problems. Let $Y$ be the class label and $X$ the features. We focus on one type of distribution shift, \emph{ label shift}, where the label marginal distribution $P_Y$ changes but the conditional distribution $P_{X|Y}$ does not. Most existing methods estimate the density ratio between the source- and target-domain label distributions by density matching. However, these methods are either computationally infeasible for large-scale data or restricted to shift correction for discrete labels. In this paper, we propose an end-to-end Label Transformation Framework (LTF) for correcting label shift, which implicitly models the shift of $P_Y$ and the conditional distribution $P_{X|Y}$ using neural networks. Thanks to the flexibility of deep networks, our framework can handle continuous, discrete, and even multi-dimensional labels in a unified way and is scalable to large data. Moreover, for high dimensional $X$, such as images, we find that the redundant information in $X$ severely degrades the estimation accuracy. To remedy this issue, we propose to match the distribution implied by our generative model and the target-domain distribution in a low-dimensional feature space that discards information irrelevant to $Y$. Both theoretical and empirical studies demonstrate the superiority of our method over previous approaches.}
+}
+
 @inproceedings{fields2019mitigating,
   title={Mitigating drift in time series data with noise augmentation},
   author={Fields, Tonya and Hsieh, George and Chenou, Jules},

--- a/menelaus/injection/__init__.py
+++ b/menelaus/injection/__init__.py
@@ -4,5 +4,5 @@ from menelaus.injection.feature_manipulation import (
     feature_swap,
     feature_hide_and_sample,
 )
-from menelaus.injection.class_manipulation import class_swap, class_join
+from menelaus.injection.class_manipulation import class_swap, class_join, class_dirichlet_shift, class_probability_shift
 from menelaus.injection.noise import brownian_noise, random_walk

--- a/menelaus/injection/__init__.py
+++ b/menelaus/injection/__init__.py
@@ -4,5 +4,10 @@ from menelaus.injection.feature_manipulation import (
     feature_swap,
     feature_hide_and_sample,
 )
-from menelaus.injection.class_manipulation import class_swap, class_join, class_dirichlet_shift, class_probability_shift
+from menelaus.injection.class_manipulation import (
+    class_swap,
+    class_join,
+    class_dirichlet_shift,
+    class_probability_shift,
+)
 from menelaus.injection.noise import brownian_noise, random_walk

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pandas as pd
 
+from sklearn.model_selection import train_test_split
+
+
+# region - simple class manipulation functions 
 
 def class_swap(data, target_col, class_1, class_2, from_index, to_index):
     """
@@ -94,3 +98,53 @@ def class_join(data, target_col, class_1, class_2, new_class, from_index, to_ind
         class_idx = class_idx[(class_idx < to_index) & (class_idx >= from_index)]
         ret[class_idx, target_col] = new_class
     return ret
+
+# endregion
+
+
+# region - LTF-inspired class manipulation functions
+
+def tweak_one_shift(X, y, shifted_class, shift_p, val_size, test_size):
+    """
+    TODO - Currently only supports ``np.array`` data - fix?
+
+    Description. 
+    
+    but first split into 3 and sample with replacement for all
+    assign p to one class, uniform to rest
+
+    Args:
+        X (np.array): input feature data
+        y (np.array): corresponding targets to inject with drift
+        shifted_class (int): TBD
+        shift_p (float):  TBD 
+        val_size (float): proportion of data to allocate for validation
+        test_size (float): proportion of data to allocate for testing
+    """
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size)
+    X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=val_size)
+    
+    for x, targets in (X,y):
+        x = x+0
+        targets = targets+0 
+
+    return X_train, X_val, X_test, y_train, y_val, y_test
+    # pf
+
+
+def minority_class_shift():
+    """
+    split into train/test and sample from each with replacement
+    to create smaller subsets??
+    20/30/40/50% of classes are set to 0.001
+    while ratios of other classes are uniform
+    """
+    pass
+
+
+def dirichlet_shift():
+    """ 
+    """
+    pass
+
+# endregion

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -150,9 +150,8 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
         raise ValueError(f"Argument {class_probabilities} has classes not found in data {all_classes}")
 
     # undefined classes are resampled uniformly
-    p_uniform = (1-sum(class_probabilities.values())) / len(undefined_classes)
     for uc in undefined_classes:
-        class_probabilities[uc] = p_uniform
+        class_probabilities[uc] = (1-sum(class_probabilities.values())) / len(undefined_classes)
 
     # distribution for each data point, and reordering of each point by class
     p_distribution = np.array([])
@@ -166,9 +165,9 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
             (cls_idx >= from_index)
         ]
 
-        # each member of class has p_class / class_size chance
-        p_individual = class_probabilities[cls] / cls_idx.shape[0]
-        
+        # each member has p_class / class_size chance, represented as bool to avoid div/0
+        p_individual = (cls_idx.shape[0] and class_probabilities[cls] / cls_idx.shape[0]) or 0
+
         # append to grouped array and corresponding distribution
         sample_grouped = np.concatenate((sample_grouped, data[cls_idx]))
         p_distribution = np.concatenate(p_distribution, np.ones(cls_idx.shape[0]) * p_individual)

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 # region - simple class manipulation functions 
 
-def class_swap(data, target_col, class_1, class_2, from_index, to_index):
+def class_swap(data, target_col, from_index, to_index, class_1, class_2):
     """
     Swaps two classes in a target column of a given dataset with each other.
     Accepts ``pandas.DataFrame`` with column names or ``numpy.ndarray``
@@ -15,10 +15,10 @@ def class_swap(data, target_col, class_1, class_2, from_index, to_index):
     Args:
         data (np.array): data to inject with drift
         target_col (int or str): column index/label of targets column
-        class_1 (int): value of first label in class swap
-        class_2 (int): value of second label in class swap
         from_index: row index at which to start class swap
         to_index: row index at which to end (non-inclusive) class swap
+        class_1 (int): value of first label in class swap
+        class_2 (int): value of second label in class swap
 
     Returns:
         np.array or pd.DataFrame: copy of data, with two classes swapped
@@ -56,7 +56,7 @@ def class_swap(data, target_col, class_1, class_2, from_index, to_index):
     return ret
 
 
-def class_join(data, target_col, class_1, class_2, new_class, from_index, to_index):
+def class_join(data, target_col, from_index, to_index, class_1, class_2, new_class):
     """
     Joins two [TODO or more?] classes in a unique class. Accepts
     ``pandas.DataFrame`` with column names or ``numpy.ndarray``
@@ -67,11 +67,11 @@ def class_join(data, target_col, class_1, class_2, new_class, from_index, to_ind
     Args:
         data (np.array): data to inject with drift
         target_col (int or str): column index/label of targets column
+        from_index: row index at which to start class join
+        to_index: row index at which to end (non-inclusive) class join
         class_1 (int): value of first label in class join
         class_2 (int): value of second label in class join,
         new_class (int): new label value to assign to old classes
-        from_index: row index at which to start class join
-        to_index: row index at which to end (non-inclusive) class join
 
     Returns:
         np.array or pd.DataFrame: copy of data, with two classes joined
@@ -102,8 +102,26 @@ def class_join(data, target_col, class_1, class_2, new_class, from_index, to_ind
 
 # region - LTF-inspired class manipulation functions
 
-def class_probability_shift(data, target_col, classes, p_classes, from_index, to_index):
+def class_probability_shift(data, target_col, from_index, to_index, classes, p_classes):
     """
+    Resamples the data over a specified window, with altered probability
+    for specified classes (and uniform probability for remaining classes).
+    Accepts ``pandas.DataFrame`` with column names or ``numpy.ndarray``
+    with column indices.
+
+    Ref. :cite:t:`LTFmethods`
+
+    Args:
+        data (np.array): data to inject with drift
+        target_col (int or str): column index/label of targets column
+        from_index: row index at which to start class swap
+        to_index: row index at which to end (non-inclusive) class swap
+        classes (list[int]): list of classes with altered sampling chance
+        p_classes (float): altered sampling chance for members of ``classes``
+
+    Returns:
+        np.array or pd.DataFrame: copy of data, resampled with shifted
+            class probability for 1 or more desired classes
     """
     ret = np.copy(data)
     classes = np.unique(ret[:, target_col])
@@ -140,17 +158,28 @@ def class_probability_shift(data, target_col, classes, p_classes, from_index, to
     return ret
 
 
-def class_dirichlet_shift(data, target_col, alpha, from_index, to_index):
+def class_dirichlet_shift(data, target_col, from_index, to_index, alpha):
     """ 
-    numpy has dirichlet shift
-    3.	Dirichlet shift:  (Doesn't appear to be implemented in os code)
-    b.	Sample from each with replacement to create smaller subsets
-    c.	"we draw p(y) from a Dirichlet distribution with concentration parameter α. With uniform p(y), Dirichlet shift is bigger for smaller α."
+    Resamples the data over a specified window, per a generated Dirichlet
+    distribution (with specified alpha) over all labels.
+    Accepts ``pandas.DataFrame`` with column names or ``numpy.ndarray``
+    with column indices.
 
-    alpha = (,,) is relative proportion for each class
-    make alpha a dict
-    sort by value
-    each number / total of numbers is prob for class
+    Ref. :cite:t:`LTFmethods`
+
+    Args:
+        data (np.array): data to inject with drift
+        target_col (int or str): column index/label of targets column
+        from_index: row index at which to start class swap
+        to_index: row index at which to end (non-inclusive) class swap
+        alpha (dict): used to derive alpha parameter for Dirichlet
+            distribution. Keys are all labels, values are the desired
+            average weight (typically ``int``) per label when resampling. 
+        p_classes (float): altered sampling chance for members of ``classes``
+
+    Returns:
+        np.array or pd.DataFrame: copy of data, resampled per Dirichlet
+            distribution over classes with specified alpha
     """
     ret = np.copy(data)
 

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -95,6 +95,7 @@ def class_join(data, target_col, from_index, to_index, class_1, class_2, new_cla
             (ret[:, target_col] == class_1) | (ret[:, target_col] == class_2)
         )[0]
         class_idx = class_idx[(class_idx < to_index) & (class_idx >= from_index)]
+
         ret[class_idx, target_col] = new_class
     return ret
 
@@ -116,7 +117,10 @@ def class_probability_shift(
 
     Note:
     * this function can perform tweak-one and minority shift
-    * TODO Warning about no labels in window given
+    * When a class is not present in the window specified,
+    but specified in ``class_probabilities``, the probability
+    value is uniformly divided into the remaining classes in
+    the window.
 
     Ref. :cite:t:`LTFmethods`
 

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -116,11 +116,12 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
     Args:
         data (np.array): data to inject with drift
         target_col (int or str): column index/label of targets column
-        from_index: row index at which to start class swap
-        to_index: row index at which to end (non-inclusive) class swap
-        class_probabilities: 
-        classes (dict): dict, 
-        p_classes (float): altered sampling chance for members of ``classes``
+        from_index (int): row index at which to start class swap
+        to_index (int): row index at which to end (non-inclusive) class swap
+        class_probabilities (dict): classes as keys, and their desired
+            resampling chance as values. Un-specified classes are given
+            a uniform resampling chance with respect to all other
+            un-specified classes
 
     Returns:
         np.array or pd.DataFrame: copy of data, resampled with shifted
@@ -136,17 +137,26 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
     else:
         raise ValueError(f"Data of type {type(data)} not supported")
 
-    if (p_classes*len(classes)) > 1:
-        raise ValueError(f"Probability of {p_classes} for {len(classes)} classes = {p_classes*len(classes)} > 1.0")
-
+    # determine all unique classes and classes not specified in args
     all_classes = np.unique(ret[:, target_col])
+    undefined_classes = [k for k in all_classes if k not in class_probabilities]
+
+    # specified class probabilities must sum to 1 or less
+    if sum(class_probabilities.values) > 1.0:
+        raise ValueError(f"Probabilities in {class_probabilities} exceed 1")
+
+    # args should not specify previously unseen classes
+    if set(all_classes) != set(list(class_probabilities.keys()) + undefined_classes):
+        raise ValueError(f"Argument {class_probabilities} has classes not found in data {all_classes}")
+
+    # undefined classes are resampled uniformly
+    p_uniform = (1-sum(class_probabilities.values)) / len(undefined_classes)
+    for uc in undefined_classes:
+        class_probabilities[uc] = p_uniform
 
     # distribution for each data point, and reordering of each point by class
     p_distribution = np.array([])
     sample_grouped = np.array([])
-
-    # locate all classes to shift
-    shifted_classes_idx = np.where(data[:, target_col].isin(classes))[0]
 
     # locate each class in window
     for cls in all_classes:
@@ -156,13 +166,9 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
             (cls_idx >= from_index)
         ]
 
-        if cls in classes:
-            # pts from shifted classes drawn with separate probability
-            p_individual = p_classes / shifted_classes_idx.shape[0]
-        else:
-            # pts from remaining classes drawn with uniform probability
-            p_individual = ((1 - p_classes) / (all_classes.shape[0] - len(classes))) / cls_idx.shape[0]
-
+        # each member of class has p_class / class_size chance
+        p_individual = class_probabilities[cls] / cls_idx.shape[0]
+        
         # append to grouped array and corresponding distribution
         sample_grouped = np.concatenate((sample_grouped, data[cls_idx]))
         p_distribution = np.concatenate(p_distribution, np.ones(cls_idx.shape[0]) * p_individual)
@@ -186,6 +192,9 @@ def class_dirichlet_shift(data, target_col, from_index, to_index, alpha):
     Accepts ``pandas.DataFrame`` with column names or ``numpy.ndarray``
     with column indices.
 
+    Note: If all labels are not given weights, unexpected behavior may
+    cause all un-specified classes to be given uniform resampling chance.
+
     Ref. :cite:t:`LTFmethods`
 
     Args:
@@ -194,7 +203,7 @@ def class_dirichlet_shift(data, target_col, from_index, to_index, alpha):
         from_index: row index at which to start class swap
         to_index: row index at which to end (non-inclusive) class swap
         alpha (dict): used to derive alpha parameter for Dirichlet
-            distribution. Keys are all labels, values are the desired
+            distribution. Keys are ALL labels, values are the desired
             average weight (typically ``int``) per label when resampling. 
             For example, weights of [4,1] correspond to an expected 80/20
             percent split between first and second classes.
@@ -202,54 +211,19 @@ def class_dirichlet_shift(data, target_col, from_index, to_index, alpha):
     Returns:
         np.array or pd.DataFrame: copy of data, resampled per Dirichlet
             distribution over classes with specified alpha
-    """
-    # if pandas.DataFrame, save columns and convert to numpy 
-    columns = None
-    if isinstance(data, pd.DataFrame):
-        ret = data.to_numpy()
-        columns = data.columns
-    elif isinstance(data, np.array):
-        ret = np.copy(data)
-    else:
-        raise ValueError(f"Data of type {type(data)} not supported")
-    
-    alpha_list = [alpha[k] for k in alpha]
-
-    if np.sum(alpha_list) > 1:
-        raise ValueError(f"Alpha values in {alpha} exceed total probability of 1.0")
+    """    
+    alpha_classes = list(alpha.keys())
+    alpha_values = [alpha[k] for k in alpha]
 
     # generate dirichlet distribution by class
-    dirichlet_distribution = np.random.dirichlet(alpha_list)
-    ret = np.copy(data)
+    # XXX - minor concern that order of these list-types not always guaranteed
+    dirichlet_distribution = np.random.dirichlet(alpha_values)
+    dirichlet_probabilities = {
+        alpha_classes[i]:dirichlet_distribution[i] 
+        for i in range(len(alpha_classes))
+    }
 
-    # distribution for each data point, and reordering of each point by class
-    p_distribution = np.array([])
-    sample_grouped = np.array([])
-
-    # locate each class in window
-    for i, cls in enumerate(alpha.keys()):
-        cls_idx = np.where(data[:, target_col] == cls)[0]
-        cls_idx = cls_idx[
-            (cls_idx < to_index) &
-            (cls_idx >= from_index)
-        ]
-
-        # pts for each class drawn with corresponding probability
-        p_individual = dirichlet_distribution[i] / cls_idx.shape[0]
-        
-        # append to grouped array and corresponding distribution
-        sample_grouped = np.concatenate((sample_grouped, data[cls_idx]))
-        p_distribution = np.concatenate(p_distribution, np.ones(cls_idx.shape[0]) * p_individual)
-
-    # shuffled sample over window, with replacement, with weights
-    sample = np.random.choice(sample_grouped, to_index-from_index, True, p_distribution)
-    ret[from_index:to_index] = sample
-
-    # back to DF if needed
-    if isinstance(data, pd.DataFrame):
-        ret = pd.DataFrame(ret)
-        ret.columns = columns
-    
-    return ret
+    # use class_probability_shift with fully-specified distribution
+    return class_probability_shift(data, target_col, from_index, to_index, dirichlet_probabilities)
 
 # endregion

--- a/menelaus/injection/class_manipulation.py
+++ b/menelaus/injection/class_manipulation.py
@@ -132,7 +132,7 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
     if isinstance(data, pd.DataFrame):
         ret = data.to_numpy()
         columns = data.columns
-    elif isinstance(data, np.array):
+    elif isinstance(data, np.ndarray):
         ret = np.copy(data)
     else:
         raise ValueError(f"Data of type {type(data)} not supported")
@@ -142,7 +142,7 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
     undefined_classes = [k for k in all_classes if k not in class_probabilities]
 
     # specified class probabilities must sum to 1 or less
-    if sum(class_probabilities.values) > 1.0:
+    if sum(class_probabilities.values()) > 1.0:
         raise ValueError(f"Probabilities in {class_probabilities} exceed 1")
 
     # args should not specify previously unseen classes
@@ -150,7 +150,7 @@ def class_probability_shift(data, target_col, from_index, to_index, class_probab
         raise ValueError(f"Argument {class_probabilities} has classes not found in data {all_classes}")
 
     # undefined classes are resampled uniformly
-    p_uniform = (1-sum(class_probabilities.values)) / len(undefined_classes)
+    p_uniform = (1-sum(class_probabilities.values())) / len(undefined_classes)
     for uc in undefined_classes:
         class_probabilities[uc] = p_uniform
 

--- a/tests/menelaus/injection/test_class_manipulation.py
+++ b/tests/menelaus/injection/test_class_manipulation.py
@@ -54,7 +54,17 @@ def test_swap_3():
         )
 
 def test_probability_shift_1():
-    pass
+    ''' Ensure probability shift causes some drift in numpy.ndarray '''
+    np.random.seed(0)
+    data = np.array([
+        [0,0,0], [1,0,0], [2,0,0], [3,0,0], [4,0,0], [5,0,0],
+        [6,0,0], [7,0,0], [8,0,0], [9,0,0]
+    ])
+    probs = {k:0.1 for k in range(0,10)}
+    new_data = class_probability_shift(data, 0, 1, 9, probs)
+    assert data[0] == new_data[0]
+    assert data[-1] == new_data[-1]
+    assert not np.array_equal(data[1:9], new_data[1:9])
 
 def test_probability_shift_2():
     pass
@@ -83,6 +93,9 @@ def test_probability_shift_5():
     with pytest.raises(ValueError):
         probs = {1000: 0.5}
         class_probability_shift(data, 0, 0, 3, probs)
+
+def test_probability_shift_6():
+    pass # with unspecified columns
 
 def test_dirichlet_shift_1():
     ''' Ensure Dirichlet shift causes some drift '''

--- a/tests/menelaus/injection/test_class_manipulation.py
+++ b/tests/menelaus/injection/test_class_manipulation.py
@@ -50,3 +50,17 @@ def test_swap_3():
             data, target_col=0, class_1=0, class_2=1, 
             from_index=1, to_index=3
         )
+
+def test_probability_shift_1():
+    pass
+
+def test_probability_shift_2():
+    ''' Check ValueError if data neither pandas.DAtaFrame nor numpy.ndarray '''
+    pass
+
+def test_dirichlet_shift_1():
+    pass
+
+def test_dirichlet_shift_2():
+    ''' Check ValueError if data neither pandas.DAtaFrame nor numpy.ndarray '''
+    pass

--- a/tests/menelaus/injection/test_class_manipulation.py
+++ b/tests/menelaus/injection/test_class_manipulation.py
@@ -10,14 +10,14 @@ def test_join_1():
     ''' Check correct join in pd.DataFrame '''
     data = pd.DataFrame({'a': [0,0,1,1], 'b': [5,5,5,5]})
     expected_data = pd.DataFrame({'a': [0,2,2,1], 'b':[5,5,5,5]})
-    data = class_join(data, 'a', 0, 1, 2, 1, 3)
+    data = class_join(data, 'a', 1, 3, 0, 1, 2)
     assert data.equals(expected_data)
 
 def test_join_2():
     ''' Check correct join in numpy.ndarray '''
     data = np.array([[0,5], [0,5], [1,5], [1,5]])
     expected_data = np.array([[0,5], [2,5], [2,5], [1,5]])
-    data = class_join(data, 0, 0, 1, 2, 1, 3)
+    data = class_join(data, 0, 1, 3, 0, 1, 2)
     assert np.array_equal(data, expected_data)
 
 def test_join_3():
@@ -33,14 +33,14 @@ def test_swap_1():
     ''' Check correct swap in pd.DataFrame '''
     data = pd.DataFrame({'a': [0,0,1,1], 'b': [5,5,6,6]})
     expected_data = pd.DataFrame({'a': [1,1,0,0], 'b':[5,5,6,6]})
-    data = class_swap(data, 'a', 0, 1, 0, 4)
+    data = class_swap(data, 'a', 0, 4, 0, 1)
     assert data.equals(expected_data)
 
 def test_swap_2():
     ''' Check correct swap in numpy.ndarray'''
     data = np.array([[0,5], [0,5], [1,6], [1,6]])
     expected_data = np.array([[1,5], [1,5], [0,6], [0,6]])
-    data = class_swap(data, 0, 0, 1, 0, 4)
+    data = class_swap(data, 0, 0, 4, 0, 1)
     assert np.array_equal(data, expected_data)
 
 def test_swap_3():
@@ -105,7 +105,17 @@ def test_probability_shift_5():
         class_probability_shift(data, 0, 0, 3, probs)
 
 def test_probability_shift_6():
-    pass # with unspecified columns
+    ''' Check drift injected when not all classes specified '''
+    np.random.seed(0)
+    data = np.array([
+        [0,0,0], [1,0,0], [2,0,0], [3,0,0], [4,0,0], [5,0,0],
+        [6,0,0], [7,0,0], [8,0,0], [9,0,0]
+    ])
+    probs = {k:0.1 for k in range(2,10)}
+    new_data = class_probability_shift(data, 0, 1, 9, probs)
+    assert np.array_equal(data[0], new_data[0])
+    assert np.array_equal(data[-1], new_data[-1])
+    assert not np.array_equal(data[1:9], new_data[1:9])
 
 def test_dirichlet_shift_1():
     ''' Ensure Dirichlet shift causes some drift '''
@@ -116,6 +126,6 @@ def test_dirichlet_shift_1():
     ])
     alpha = {k:1 for k in range(0,10)}
     new_data = class_dirichlet_shift(data, 0, 1, 9, alpha)
-    assert data[0] == new_data[0]
-    assert data[-1] == new_data[-1]
+    assert np.array_equal(data[0], new_data[0])
+    assert np.array_equal(data[-1], new_data[-1])
     assert not np.array_equal(data[1:9], new_data[1:9])

--- a/tests/menelaus/injection/test_class_manipulation.py
+++ b/tests/menelaus/injection/test_class_manipulation.py
@@ -2,7 +2,6 @@ import pytest
 import pandas as pd
 import numpy as np
 
-from collections import defaultdict
 
 from menelaus.injection import class_join, class_swap, class_probability_shift, class_dirichlet_shift
 
@@ -62,12 +61,23 @@ def test_probability_shift_1():
     ])
     probs = {k:0.1 for k in range(0,10)}
     new_data = class_probability_shift(data, 0, 1, 9, probs)
-    assert data[0] == new_data[0]
-    assert data[-1] == new_data[-1]
+    assert np.array_equal(data[0], new_data[0])
+    assert np.array_equal(data[-1], new_data[-1])
     assert not np.array_equal(data[1:9], new_data[1:9])
 
 def test_probability_shift_2():
-    pass
+    ''' Ensure probability shift causes some drift in pandas.DataFrame '''
+    np.random.seed(0)
+    data = pd.DataFrame({
+        'a': [0,1,2,3,4,5,6,7,8,9],
+        'b': [0,0,0,0,0,0,0,0,0,0]
+    })
+    probs = {k:0.1 for k in range(0,10)}
+    new_data = class_probability_shift(data, 0, 1, 9, probs)
+    assert data.iloc[0].equals(new_data.iloc[0])
+    assert data.iloc[-1].equals(new_data.iloc[-1])
+    assert not np.array_equal(data[1:9], new_data[1:9])
+    assert list(new_data.columns) == ['a', 'b']
 
 def test_probability_shift_3():
     ''' Check ValueError if data neither pandas.DataFrame nor numpy.ndarray '''


### PR DESCRIPTION
Closes #125 

### Added
- functions for injecting drift according to Dirichlet, tweak-one, and minority shift methods
- accompanying tests/documentation

### Details
- excludes other drift injection techniques that may be implemented elsewhere in OS code

### Checklist
- [ ] tests added and passing
- [x] docs added and building
- [x] pandas support added