### PR TITLE
State / retraining properties for ensemble

### DIFF
--- a/menelaus/ensemble/ensemble.py
+++ b/menelaus/ensemble/ensemble.py
@@ -16,8 +16,9 @@ class Ensemble:
     detectors per some voting scheme.
 
     Any class hoping to implement ensemble functionality should implement
-    from this. 
+    from this.
     """
+
     def __init__(self, detectors: dict, election, column_selectors: dict = {}):
         # XXX - Since rigid type-checking is sort of discouraged in Python
         #       it makes the most sense to just treat election as (always)
@@ -64,8 +65,11 @@ class Ensemble:
         Returns dict where keys are detector identifiers as specified in ``self.detectors``,
         values are drift states for corresponding detector objects.
         """
-        return {detector_id:detector.drift_state for detector_id, detector in self.detectors.items()}
-    
+        return {
+            detector_id: detector.drift_state
+            for detector_id, detector in self.detectors.items()
+        }
+
     @property
     def retraining_recs(self):
         """
@@ -76,7 +80,7 @@ class Ensemble:
         ret = {}
         for detector_id, detector in self.detectors.items():
             # XXX - some explicit handling may be better practice than hasattr
-            if hasattr(detector, 'retraining_recs'):
+            if hasattr(detector, "retraining_recs"):
                 ret[detector_id] = detector.retraining_recs
         return ret
 
@@ -98,7 +102,7 @@ class StreamingEnsemble(StreamingDetector, Ensemble):
             keys of ``detectors``. A column selector function for a given
             key determines how data is selected to be fed into that detector.
         drift_state (str or None): Overall ensemble drift state. Can be ``"drift"``,
-            ``"warning"``, or ``None``. 
+            ``"warning"``, or ``None``.
         drift_states (dict): ``dict`` of drift states whose keys match the keys
             of ``detectors``, and whose values are the drift states for those
             detector objects
@@ -169,7 +173,7 @@ class BatchEnsemble(BatchDetector, Ensemble):
             keys of ``detectors``. A column selector function for a given
             key determines how data is selected to be fed into that detector.
         drift_state (str or None): Overall ensemble drift state. Can be ``"drift"``,
-            ``"warning"``, or ``None``. 
+            ``"warning"``, or ``None``.
         drift_states (dict): ``dict`` of drift states whose keys match the keys
             of ``detectors``, and whose values are the drift states for those
             detector objects

--- a/menelaus/ensemble/ensemble.py
+++ b/menelaus/ensemble/ensemble.py
@@ -17,20 +17,7 @@ class Ensemble:
 
     Any class hoping to implement ensemble functionality should implement
     from this. 
-
-    Attributes
-    ----------
-    -
-    drift state
-    column selectors
-    detectors
-    election
-    drift states
-    retraining recs
-    
-    ? TODO
     """
-
     def __init__(self, detectors: dict, election, column_selectors: dict = {}):
         # XXX - Since rigid type-checking is sort of discouraged in Python
         #       it makes the most sense to just treat election as (always)
@@ -84,8 +71,14 @@ class Ensemble:
         """
         Returns dict where keys are detector identifiers as specified in ``self.detectors``,
         values are retraining recommendation values from corresponding detector objects.
+        Detectors which do not have retraining recommendations are skipped in the output.
         """
-        return None
+        ret = {}
+        for detector_id, detector in self.detectors.items():
+            # XXX - some explicit handling may be better practice than hasattr
+            if hasattr(detector, 'retraining_recs'):
+                ret[detector_id] = detector.retraining_recs
+        return ret
 
 
 class StreamingEnsemble(StreamingDetector, Ensemble):
@@ -95,6 +88,24 @@ class StreamingEnsemble(StreamingDetector, Ensemble):
     IS-A ``StreamingDetector``). As such it has the functions of a regular
     detector: ``update``, ``reset``, etc. Internally, these operate not only
     on the ensemble's own attributes, but on the set of detectors given to it.
+
+    Attributes:
+        detectors (dict): ``dict`` of detector objects, keyed by unique string
+            identifiers
+        election (menelaus.ensemble.Election): election object to dictate how
+            overall ensemble drift state is determined
+        column_selectors (dict): ``dict`` of functions, whose keys match the
+            keys of ``detectors``. A column selector function for a given
+            key determines how data is selected to be fed into that detector.
+        drift_state (str or None): Overall ensemble drift state. Can be ``"drift"``,
+            ``"warning"``, or ``None``. 
+        drift_states (dict): ``dict`` of drift states whose keys match the keys
+            of ``detectors``, and whose values are the drift states for those
+            detector objects
+        retraining_recs (dict): ``dict`` of retraining recommendations whose keys
+            match the keys of ``detectors``, and whose values are the retraining
+            recommendations for those detector objects. Detectors who do not
+            have retraining options are skipped.
     """
 
     def __init__(self, detectors: dict, election, column_selectors: dict = {}):
@@ -148,6 +159,24 @@ class BatchEnsemble(BatchDetector, Ensemble):
     As such it has the functions of a regular detector, ``set_reference``,
     ``update``, and ``reset``. These functions will operate not only on the
     ensemble's own attributes, but on the set of detectors given to it.
+
+    Attributes:
+        detectors (dict): ``dict`` of detector objects, keyed by unique string
+            identifiers
+        election (menelaus.ensemble.Election): election object to dictate how
+            overall ensemble drift state is determined
+        column_selectors (dict): ``dict`` of functions, whose keys match the
+            keys of ``detectors``. A column selector function for a given
+            key determines how data is selected to be fed into that detector.
+        drift_state (str or None): Overall ensemble drift state. Can be ``"drift"``,
+            ``"warning"``, or ``None``. 
+        drift_states (dict): ``dict`` of drift states whose keys match the keys
+            of ``detectors``, and whose values are the drift states for those
+            detector objects
+        retraining_recs (dict): ``dict`` of retraining recommendations whose keys
+            match the keys of ``detectors``, and whose values are the retraining
+            recommendations for those detector objects. Detectors who do not
+            have retraining options are skipped.
     """
 
     def __init__(self, detectors: dict, election, column_selectors: dict = {}):

--- a/menelaus/ensemble/ensemble.py
+++ b/menelaus/ensemble/ensemble.py
@@ -16,7 +16,19 @@ class Ensemble:
     detectors per some voting scheme.
 
     Any class hoping to implement ensemble functionality should implement
-    from this.
+    from this. 
+
+    Attributes
+    ----------
+    -
+    drift state
+    column selectors
+    detectors
+    election
+    drift states
+    retraining recs
+    
+    ? TODO
     """
 
     def __init__(self, detectors: dict, election, column_selectors: dict = {}):
@@ -58,6 +70,22 @@ class Ensemble:
         """
         for det_key in self.detectors:
             self.detectors[det_key].reset()
+
+    @property
+    def drift_states(self):
+        """
+        Returns dict where keys are detector identifiers as specified in ``self.detectors``,
+        values are drift states for corresponding detector objects.
+        """
+        return {detector_id:detector.drift_state for detector_id, detector in self.detectors.items()}
+    
+    @property
+    def retraining_recs(self):
+        """
+        Returns dict where keys are detector identifiers as specified in ``self.detectors``,
+        values are retraining recommendation values from corresponding detector objects.
+        """
+        return None
 
 
 class StreamingEnsemble(StreamingDetector, Ensemble):

--- a/tests/menelaus/test_ensemble.py
+++ b/tests/menelaus/test_ensemble.py
@@ -27,7 +27,6 @@ def test_stream_ensemble_1():
     se.update(X=df.iloc[[0]], y_true=0, y_pred=0)
     assert se.drift_state == None
 
-
 def test_stream_ensemble_2():
     """Ensure stream ensemble executes when columns specified"""
     step1 = STEPD(window_size=2)
@@ -48,7 +47,6 @@ def test_stream_ensemble_2():
     df = pd.DataFrame({"a": [0,0], "b": [0,0], "c": [0,0]})
     se.update(X=df.iloc[[0]], y_true=0, y_pred=0)
     assert se.drift_state == None
-
 
 def test_stream_ensemble_3():
     """Ensure stream ensemble executes with univariate data"""
@@ -71,7 +69,6 @@ def test_stream_ensemble_3():
     df = pd.DataFrame({"a": [0,0], "b": [0,0], "c": [0,0]})
     se.update(X=df.iloc[[0]], y_true=0, y_pred=0)
     assert se.drift_state == None
-
 
 def test_stream_ensemble_reset_1():
     """Ensure reset works in stream ensemble and its detectors"""
@@ -105,7 +102,7 @@ def test_stream_ensemble_reset_1():
 # region - general tests
 
 def test_ensemble_drift_states_1():
-    """ """
+    """ Check member drift states are correctly reported by attribute """
     adwin1 = ADWIN()
     adwin2 = ADWIN()
     adwin3 = ADWIN()
@@ -120,10 +117,21 @@ def test_ensemble_drift_states_1():
     se.detectors['a2'].drift_state = "warning"    
     assert se.drift_states == {"a1": "drift", "a2": "warning", "a3": None}
 
-
 def test_ensemble_recs_1():
-    """ """
-    assert False
+    """ Check member retraining recs are correctly reported by attribute """
+    adwin1 = ADWIN()
+    adwin2 = ADWIN()
+    adwin3 = ADWIN()
+
+    se = StreamingEnsemble(
+        detectors={"a1": adwin1, "a2": adwin2, "a3": adwin3},
+        election=SimpleMajorityElection(),
+        column_selectors={}
+    )
+
+    se.detectors['a1'].retraining_recs = "PLACEHOLDER VALUE"
+    se.detectors['a2'].retraining_recs = "PLACEHOLDER VALUE"    
+    assert se.drift_states == {"a1": "PLACEHOLDER VALUE", "a2": "PLACEHOLDER VALUE"}
 
 # endregion
 
@@ -148,7 +156,6 @@ def test_batch_ensemble_1():
     be.set_reference(df.loc[:1])
     be.update(df.loc[2:])
     assert be.drift_state == None
-
 
 def test_batch_ensemble_2():
     """Ensure batch ensemble executes when columns specified"""
@@ -175,7 +182,6 @@ def test_batch_ensemble_2():
     be.update(df.loc[2:])
     assert len(be.detectors["k1"]._input_cols) == 2
     assert len(be.detectors["k2"]._input_cols) == 2
-
 
 def test_batch_ensemble_reset_1():
     """Ensure reset works in batch ensemble and its detectors"""
@@ -224,7 +230,6 @@ def test_eval_simple_majority_1():
     election = SimpleMajorityElection()
     assert election([det1, det2, det3]) == "drift"
 
-
 def test_eval_simple_majority_2():
     """Ensure simple majority scheme does not false alarm"""
     det1 = det2 = KdqTreeBatch()
@@ -233,7 +238,6 @@ def test_eval_simple_majority_2():
     det3.drift_state = "drift"
     election = SimpleMajorityElection()
     assert election([det1, det2, det3]) == None
-
 
 def test_eval_min_election_1():
     """Ensure minimimum approval scheme can identify drift"""
@@ -244,7 +248,6 @@ def test_eval_min_election_1():
     election = MinimumApprovalElection(approvals_needed=2)
     assert election([s1, s2, s3]) == "drift"
 
-
 def test_eval_min_election_2():
     """Ensure minimimum approval scheme does not false alarm"""
     s1 = s2 = STEPD()
@@ -253,7 +256,6 @@ def test_eval_min_election_2():
     s3.drift_state = "drift"
     election = MinimumApprovalElection(approvals_needed=2)
     assert election([s1, s2, s3]) == None
-
 
 def test_eval_ordered_election_1():
     """Ensure confirmed approval scheme can identify drift"""
@@ -267,7 +269,6 @@ def test_eval_ordered_election_1():
     )
     assert election([s1, s2, s3]) == "drift"
 
-
 def test_eval_ordered_election_2():
     """Ensure confirmed approval scheme does not false alarm"""
     s1 = s2 = STEPD()
@@ -280,7 +281,6 @@ def test_eval_ordered_election_2():
     )
     assert election([s1, s2, s3]) == None
 
-
 def test_confirmed_election_1():
     """Ensure ConfirmedElection can detect drift"""
     d1 = ADWIN()
@@ -291,7 +291,6 @@ def test_confirmed_election_1():
     election([d1,d2,d3]) # call #1
     d2.drift_state = "drift"
     assert election([d1, d2, d3]) == "drift" # by call #2, drift
-
 
 def test_confirmed_election_2():
     """Ensure ConfirmedElection can detect warnings"""
@@ -304,7 +303,6 @@ def test_confirmed_election_2():
     d2.drift_state = "warning"
     assert election([d1, d2, d3]) == "warning" # by call #2, warning
 
-
 def test_confirmed_election_3():
     """Ensure ConfirmedElection does not false alarm"""
     d1 = ADWIN()
@@ -314,7 +312,6 @@ def test_confirmed_election_3():
     election = ConfirmedElection(sensitivity=2, wait_time=10)
     election([d1, d2, d3]) # call 1
     assert election([d1, d2, d3]) == None # no more drift, so call 2 : None
-
 
 def test_confirmed_election_4():
     """Ensure resetting of wait period counters"""

--- a/tests/menelaus/test_ensemble.py
+++ b/tests/menelaus/test_ensemble.py
@@ -121,17 +121,18 @@ def test_ensemble_recs_1():
     """ Check member retraining recs are correctly reported by attribute """
     adwin1 = ADWIN()
     adwin2 = ADWIN()
-    adwin3 = ADWIN()
+    k1 = KdqTreeBatch()
 
     se = StreamingEnsemble(
-        detectors={"a1": adwin1, "a2": adwin2, "a3": adwin3},
+        detectors={"a1": adwin1, "a2": adwin2, "k1": k1},
         election=SimpleMajorityElection(),
         column_selectors={}
     )
 
-    se.detectors['a1'].retraining_recs = "PLACEHOLDER VALUE"
-    se.detectors['a2'].retraining_recs = "PLACEHOLDER VALUE"    
-    assert se.drift_states == {"a1": "PLACEHOLDER VALUE", "a2": "PLACEHOLDER VALUE"}
+    se.detectors['a1']._retraining_recs = "PLACEHOLDER VALUE"
+    se.detectors['a2']._retraining_recs = "PLACEHOLDER VALUE"  
+    assert not hasattr(k1, "retraining_recs")  
+    assert se.retraining_recs == {"a1": "PLACEHOLDER VALUE", "a2": "PLACEHOLDER VALUE"}
 
 # endregion
 

--- a/tests/menelaus/test_ensemble.py
+++ b/tests/menelaus/test_ensemble.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from menelaus.ensemble import Ensemble, StreamingEnsemble, BatchEnsemble
+from menelaus.ensemble import StreamingEnsemble, BatchEnsemble
 from menelaus.ensemble import (
     SimpleMajorityElection,
     MinimumApprovalElection,
@@ -11,6 +11,8 @@ from menelaus.data_drift import KdqTreeBatch
 from menelaus.concept_drift import STEPD
 from menelaus.change_detection import ADWIN
 
+
+# region - test stream ensemble
 
 def test_stream_ensemble_1():
     """Ensure stream ensemble executes with no drift"""
@@ -98,6 +100,34 @@ def test_stream_ensemble_reset_1():
         assert be.detectors[det_key].drift_state == None
         assert be.detectors[det_key].total_samples == 1
 
+# endregion
+
+# region - general tests
+
+def test_ensemble_drift_states_1():
+    """ """
+    adwin1 = ADWIN()
+    adwin2 = ADWIN()
+    adwin3 = ADWIN()
+
+    se = StreamingEnsemble(
+        detectors={"a1": adwin1, "a2": adwin2, "a3": adwin3},
+        election=SimpleMajorityElection(),
+        column_selectors={}
+    )
+
+    se.detectors['a1'].drift_state = "drift"
+    se.detectors['a2'].drift_state = "warning"    
+    assert se.drift_states == {"a1": "drift", "a2": "warning", "a3": None}
+
+
+def test_ensemble_recs_1():
+    """ """
+    assert False
+
+# endregion
+
+# region - test batch ensemble 
 
 def test_batch_ensemble_1():
     """Ensure batch ensemble executes with no drift"""
@@ -181,6 +211,9 @@ def test_batch_ensemble_reset_1():
         assert be.detectors[det_key].drift_state == None
         assert be.detectors[det_key].total_batches == 1
 
+# endregion
+
+# region - election tests
 
 def test_eval_simple_majority_1():
     """Ensure simple majority scheme can identify drift"""
@@ -292,3 +325,5 @@ def test_confirmed_election_4():
     assert election.wait_period_counters[0] == 1
     election([d1]) # wait period counter for d1 would be 2, so rest to 0
     assert election.wait_period_counters[0] == 0
+
+# endregion


### PR DESCRIPTION
Closes #133 

### Added
- `Ensemble.drift_states` returns `dict` of member drift states
- `Ensemble.retraining_recs` returns `dict` of member retraining recommendations, if they exist

### Changed
- improved unit testing and documentation for ensemble modules